### PR TITLE
minor improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "easybench"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +324,7 @@ name = "natives-gen"
 version = "0.1.0"
 dependencies = [
  "convert_case",
+ "dotenv",
  "full_moon",
  "itertools",
  "joaat",

--- a/natives-gen/Cargo.toml
+++ b/natives-gen/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["ZOTTCE <zottce@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+dotenv = "0.15.0"
 full_moon = "0.11.0"
 joaat = "0.1.0"
 itertools = "0.10.0"

--- a/natives-gen/src/main.rs
+++ b/natives-gen/src/main.rs
@@ -23,11 +23,14 @@ fn main() {
     let folder: PathBuf = std::env::var("EXT_NATIVES")
         .unwrap_or("E:/sources/c/fivem-fork/ext/natives".to_string())
         .into();
+
     exists_or_panic(&folder);
+
     let codegen_types_path = folder.join("codegen_types.lua");
     let rpc_spec_natives_path = folder.join("rpc_spec_natives.lua");
     let natives_cfx_path = folder.join("inp/natives_cfx.lua");
     let natives_global_path = folder.join("inp/natives_global.lua");
+
     exists_or_panic(&codegen_types_path);
     exists_or_panic(&rpc_spec_natives_path);
     exists_or_panic(&natives_cfx_path);
@@ -37,7 +40,6 @@ fn main() {
     let rpcs = rpcs_from_file(&rpc_spec_natives_path);
 
     let natives_cfx = natives_from_file(&natives_cfx_path, ApiSet::Server);
-
     let natives_global = natives_from_file(&natives_global_path, ApiSet::Client);
 
     let natives = natives_global.into_iter().chain(natives_cfx);

--- a/natives-gen/src/main.rs
+++ b/natives-gen/src/main.rs
@@ -1,29 +1,44 @@
-use itertools::Itertools;
-
 pub(crate) mod natives;
 pub(crate) mod parser;
 pub(crate) mod rpcs;
 pub(crate) mod types;
 
+use dotenv::dotenv;
+use itertools::Itertools;
 use natives::*;
 use rpcs::{extend_natives_with_rpcs, rpcs_from_file};
+use std::path::PathBuf;
 use types::types_from_file;
 
+fn exists_or_panic(path: &PathBuf) {
+    if !path.exists() {
+        panic!("{:#?} does not exists", path);
+    }
+}
+
 fn main() {
+    dotenv().ok();
     let return_style = ReturnStyle::UnwrapOrDefault;
 
-    let mut types = types_from_file("E:/sources/c/fivem-fork/ext/natives/codegen_types.lua");
-    let rpcs = rpcs_from_file("E:/sources/c/fivem-fork/ext/natives/rpc_spec_natives.lua");
+    let folder: PathBuf = std::env::var("EXT_NATIVES")
+        .unwrap_or("E:/sources/c/fivem-fork/ext/natives".to_string())
+        .into();
+    exists_or_panic(&folder);
+    let codegen_types_path = folder.join("codegen_types.lua");
+    let rpc_spec_natives_path = folder.join("rpc_spec_natives.lua");
+    let natives_cfx_path = folder.join("inp/natives_cfx.lua");
+    let natives_global_path = folder.join("inp/natives_global.lua");
+    exists_or_panic(&codegen_types_path);
+    exists_or_panic(&rpc_spec_natives_path);
+    exists_or_panic(&natives_cfx_path);
+    exists_or_panic(&natives_global_path);
 
-    let natives_cfx = natives_from_file(
-        "E:/sources/c/fivem-fork/ext/natives/inp/natives_cfx.lua",
-        ApiSet::Server,
-    );
+    let mut types = types_from_file(&codegen_types_path);
+    let rpcs = rpcs_from_file(&rpc_spec_natives_path);
 
-    let natives_global = natives_from_file(
-        "E:/sources/c/fivem-fork/ext/natives/inp/natives_global.lua",
-        ApiSet::Client,
-    );
+    let natives_cfx = natives_from_file(&natives_cfx_path, ApiSet::Server);
+
+    let natives_global = natives_from_file(&natives_global_path, ApiSet::Client);
 
     let natives = natives_global.into_iter().chain(natives_cfx);
     let mut sets = natives.into_group_map_by(|native| native.apiset);

--- a/natives-gen/src/natives.rs
+++ b/natives-gen/src/natives.rs
@@ -2,6 +2,7 @@ use convert_case::{Case, Casing};
 use itertools::Itertools;
 use std::collections::HashMap;
 use std::io::*;
+use std::path::PathBuf;
 
 use crate::parser::*;
 use crate::types::*;
@@ -73,6 +74,7 @@ pub struct RustArgument {
     pub ty: RustType,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 pub enum ReturnStyle {
     /// Full unwrap
@@ -125,7 +127,7 @@ impl Default for ApiSet {
     }
 }
 
-pub fn natives_from_file(file: &str, default_set: ApiSet) -> Vec<CfxNative> {
+pub fn natives_from_file(file: &PathBuf, default_set: ApiSet) -> Vec<CfxNative> {
     let params = parse_file(file);
     format_natives(params, default_set)
 }

--- a/natives-gen/src/parser.rs
+++ b/natives-gen/src/parser.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use full_moon::ast::{
     Call, Expression, Field, FunctionArgs, FunctionCall, Prefix, Stmt, Suffix, Value,
@@ -116,8 +116,7 @@ fn unwrap(stmt: &Stmt) -> Option<FuncExec> {
     }
 }
 
-pub fn parse_file(file: &PathBuf) -> Vec<FuncExec> {
-    println!("{:#?}", file);
+pub fn parse_file<T: AsRef<Path>>(file: &T) -> Vec<FuncExec> {
     let types = std::fs::read_to_string(file).unwrap();
     let ast_types = full_moon::parse(&types).unwrap();
 

--- a/natives-gen/src/parser.rs
+++ b/natives-gen/src/parser.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use full_moon::ast::{
     Call, Expression, Field, FunctionArgs, FunctionCall, Prefix, Stmt, Suffix, Value,
 };
@@ -114,7 +116,8 @@ fn unwrap(stmt: &Stmt) -> Option<FuncExec> {
     }
 }
 
-pub fn parse_file(file: &str) -> Vec<FuncExec> {
+pub fn parse_file(file: &PathBuf) -> Vec<FuncExec> {
+    println!("{:#?}", file);
     let types = std::fs::read_to_string(file).unwrap();
     let ast_types = full_moon::parse(&types).unwrap();
 

--- a/natives-gen/src/rpcs.rs
+++ b/natives-gen/src/rpcs.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 use crate::{
     natives::{ApiSet, CfxNative},
@@ -42,7 +42,7 @@ fn format_rpcs(rpcs: Vec<FuncExec>) -> Vec<Rpc> {
         .collect()
 }
 
-pub fn rpcs_from_file(file: &str) -> Vec<Rpc> {
+pub fn rpcs_from_file(file: &PathBuf) -> Vec<Rpc> {
     let rpcs = parse_file(file);
     format_rpcs(rpcs)
 }

--- a/natives-gen/src/types.rs
+++ b/natives-gen/src/types.rs
@@ -1,5 +1,5 @@
 use crate::parser::{parse_file, Argument, FuncExec};
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 #[derive(Debug, Default, Clone)]
 pub struct CfxType {
@@ -198,7 +198,7 @@ fn format_types(types: Vec<FuncExec>) -> HashMap<String, CfxType> {
     formated
 }
 
-pub fn types_from_file(file: &str) -> HashMap<String, CfxType> {
+pub fn types_from_file(file: &PathBuf) -> HashMap<String, CfxType> {
     let types = parse_file(file);
     format_types(types)
 }


### PR DESCRIPTION
this is a very small PR for convenience :
- it allows for specifying the folder used in `natives-gen` via the env var `EXT_NATIVES` or otherwise fallback to the repo maintainer hardcoded path (slightly more convenient)
- it changes `&str` for `&PathBuf` in functions arguments whenever specifying file path (slightly more idiomatic)
- it checks the existence of the folder and the expected files before processing, panicking if ever they're missing